### PR TITLE
Refactor Hexdump::Client to allow simpler extension

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -18,6 +18,18 @@ class ClientTest < Minitest::Test
     assert client.execute("SHOW TABLES")
   end
 
+  def test_include_columns
+    client = Hexspace::Client.new(
+      mode: (ENV["HEXSPACE_MODE"] || :sasl).to_sym,
+      database: "hexspace_test",
+      include_columns: true
+    )
+    client.execute("CREATE TABLE users (id INT, name STRING)")
+    rows, columns = client.execute("SELECT * FROM users")
+    assert_empty rows
+    assert_equal ["id", "name"], columns
+  end
+
   def test_current_database
     assert_equal "hexspace_test", client.execute("SELECT current_database() AS value").first["value"]
   end


### PR DESCRIPTION
I'm working on a sequel-hexspace adapter, which requires:

* Column names must be symbols

* timestamp types need to be converted using a Sequel method that handles configured timezones

* binary types need to be converted to a Sequel-specific type

* Columns in a result set should be accessible even if the result set has no rows.

This is currently only possible by subclassing Hexspace::Client and overriding process_results, which is quite a large method. This extracts the following methods from process_results:

* column_names(metadata)

* type_converter(type)

It adds one keyword argument to the initializer for whether process_results should include columns as a second return value.

This makes the overriding sequel-hexspace needs to do much simpler: https://github.com/jeremyevans/sequel-hexspace/commit/e70efc8b75e7320598a2ac0e7b6d3b05edb9327e